### PR TITLE
Use existing reference of association if not null

### DIFF
--- a/plugin/src/main/groovy/gorm/tools/databinding/EntityMapBinder.groovy
+++ b/plugin/src/main/groovy/gorm/tools/databinding/EntityMapBinder.groovy
@@ -195,10 +195,12 @@ class EntityMapBinder extends GrailsWebDataBinder implements MapBinder {
 
         if (association.getType().isAssignableFrom(value.getClass())) {
             instance = value
-        } else if (association.isOwningSide() && value instanceof Map) {
+        } else if (value instanceof Map && target[association.name] != null &&  !value.containsKey('id')) {
+            //use existing reference if not null
+            instance = target[association.name]
+        } else if (value instanceof Map && association.isOwningSide()) {
             instance = association.type.newInstance()
-        }
-        else {
+        } else {
             Object idValue = isDomainClass(value.getClass()) ? value['id'] : getIdentifierValueFrom(value)
             if (idValue != 'null' && idValue != null && idValue != '') {
                 instance = getPersistentInstance(getDomainClassType(target, association.name), idValue)
@@ -239,7 +241,7 @@ class EntityMapBinder extends GrailsWebDataBinder implements MapBinder {
     @SuppressWarnings(["EmptyCatchBlock"])
     protected getPersistentInstance(Class<?> type, id) {
         try {
-            GormEnhancer.findStaticApi(type).load((Serializable)id)
+            GormEnhancer.findStaticApi(type).load((Serializable) id)
         } catch (Exception exc) {
         }
     }

--- a/plugin/src/test/groovy/gorm/tools/databinding/EntityMapBinderUnitSpec.groovy
+++ b/plugin/src/test/groovy/gorm/tools/databinding/EntityMapBinderUnitSpec.groovy
@@ -219,6 +219,22 @@ class EntityMapBinderUnitSpec extends Specification implements DataRepoTest {
         testDomain.nested.name == "test"
     }
 
+    void "binder should not create new association if its reference is not null"() {
+        TestDomain testDomain = new TestDomain()
+        Nested nested = new Nested(name2:"xxxx")
+        testDomain.nested = nested
+        Map params = [name: 'test', nested:[name:"test"]]
+
+        when:
+        binder.bind(testDomain, params)
+
+        then:
+        testDomain.name == "test"
+        testDomain.nested != null
+        testDomain.nested.is(nested)
+        testDomain.nested.name == "test"
+    }
+
     void "binder should load existing association if it does not belongsTo"() {
         TestDomain testDomain = new TestDomain()
         AnotherDomain anotherDomain = new AnotherDomain(id:1, name:"name").save()
@@ -234,7 +250,7 @@ class EntityMapBinderUnitSpec extends Specification implements DataRepoTest {
         testDomain.anotherDomain.name != "test" //should not be deep bound if does not belogsTo
     }
 
-    void "binder should set reference if value if of association type"() {
+    void "binder should set reference if value is of association type"() {
         TestDomain testDomain = new TestDomain()
         AnotherDomain anotherDomain = new AnotherDomain(id:1, name:"name").save()
         Map params = [name: 'test', anotherDomain:anotherDomain]
@@ -280,10 +296,12 @@ class AnotherDomain {
 @Entity
 class Nested {
     String name
+    String name2
 
     static belongsTo = [TestDomain]
 
     static constraints = {
         name nullable: false
+        name2 nullable: true
     }
 }


### PR DESCRIPTION

This makes it possible to update association in beforeBind, and still stops it from being overriden during bind