### PR TITLE
Wrap exists in trx

### DIFF
--- a/examples/testify/src/integration-test/groovy/gorm/tools/repository/KitchenSinkRepoIntegrationTest.groovy
+++ b/examples/testify/src/integration-test/groovy/gorm/tools/repository/KitchenSinkRepoIntegrationTest.groovy
@@ -49,4 +49,12 @@ class KitchenSinkRepoIntegrationTest extends Specification implements DomainIntT
             sink.delete()
         }
     }
+
+    //not transactional, to verify that "exists" wraps query in trx
+    @NotTransactional
+    void "test exists"() {
+        expect:
+        KitchenSink.repo.exists(1L)
+        !KitchenSink.repo.exists(999999)
+    }
 }

--- a/examples/testify/src/integration-test/groovy/gorm/tools/repository/KitchenSinkRepoIntegrationTest.groovy
+++ b/examples/testify/src/integration-test/groovy/gorm/tools/repository/KitchenSinkRepoIntegrationTest.groovy
@@ -55,6 +55,6 @@ class KitchenSinkRepoIntegrationTest extends Specification implements DomainIntT
     void "test exists"() {
         expect:
         KitchenSink.repo.exists(1L)
-        !KitchenSink.repo.exists(999999)
+        !KitchenSink.repo.exists(999999L)
     }
 }

--- a/gorm-tools/src/main/groovy/gorm/tools/mango/api/QueryMangoEntityApi.groovy
+++ b/gorm-tools/src/main/groovy/gorm/tools/mango/api/QueryMangoEntityApi.groovy
@@ -33,6 +33,7 @@ trait QueryMangoEntityApi<D> {
 
     //implemented by GormRepo
     abstract public <D> D withTrx(Closure<D> callable)
+    abstract public <D> D withReadOnlyTrx(Closure<D> callable)
 
     /**
      * Primary method. Builds detached criteria for repository's domain based on mango criteria language and additional criteria
@@ -112,10 +113,12 @@ trait QueryMangoEntityApi<D> {
     }
 
     /**
-     * performant way to check if id exists in database.
+     * Performant way to check if id exists in database.
      */
     boolean exists(Serializable id) {
-        if( !idExistsQuery ) idExistsQuery = KeyExistsQuery.of(getEntityClass())
-        return idExistsQuery.exists(id)
+        withReadOnlyTrx {
+            if (!idExistsQuery) idExistsQuery = KeyExistsQuery.of(getEntityClass())
+            return idExistsQuery.exists(id)
+        }
     }
 }

--- a/gorm-tools/src/main/groovy/gorm/tools/repository/GormRepo.groovy
+++ b/gorm-tools/src/main/groovy/gorm/tools/repository/GormRepo.groovy
@@ -421,7 +421,7 @@ trait GormRepo<D> implements BulkableRepo<D>, QueryMangoEntityApi<D> {
      * @return the retrieved entity
      */
     D read(Serializable id) {
-        entityReadOnlyTrx {
+        withReadOnlyTrx {
             (D) gormStaticApi().read(id)
         }
     }
@@ -620,7 +620,7 @@ trait GormRepo<D> implements BulkableRepo<D>, QueryMangoEntityApi<D> {
      * @param callable The closure to call
      * @return The entity that was run in the closure
      */
-    D entityReadOnlyTrx(Closure<D> callable) {
+    public <T> T withReadOnlyTrx(Closure<T> callable) {
         def trxAttr = new CustomizableRollbackTransactionAttribute()
         trxAttr.readOnly = true
         gormStaticApi().withTransaction(trxAttr, callable)


### PR DESCRIPTION
@basejump I have made change to wrap "exists" in a readonly trx

Why this change ?
- Often we need to check if "record exists", from controllers, services, or other code, so that we can return a not found problem etc
- However, often, we dont have a "transaction" going on, mainly, because we want to return "result" and so method is not transaction
- So we have to do thing like "getWithTrx" or add another "transactional" method so we can run the check


"exists" which joins current transaction, or "starts a new readonly" transaction would help in these cases

