### PR TITLE
#2162 Add InvalidApiCallEvent

### DIFF
--- a/gorm-rest/src/main/groovy/yakworks/rest/log/InvalidApiCallEvent.groovy
+++ b/gorm-rest/src/main/groovy/yakworks/rest/log/InvalidApiCallEvent.groovy
@@ -1,3 +1,7 @@
+/*
+* Copyright 2023 Yak.Works - Licensed under the Apache License, Version 2.0 (the "License")
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
 package yakworks.rest.log
 
 import org.springframework.context.ApplicationEvent

--- a/gorm-rest/src/main/groovy/yakworks/rest/log/InvalidApiCallEvent.groovy
+++ b/gorm-rest/src/main/groovy/yakworks/rest/log/InvalidApiCallEvent.groovy
@@ -1,0 +1,21 @@
+package yakworks.rest.log
+
+import org.springframework.context.ApplicationEvent
+
+class InvalidApiCallEvent extends ApplicationEvent {
+
+    String code
+    String title
+    String detail
+    String user
+    Object payload
+
+    InvalidApiCallEvent(String code, String title, String detail, String user = null, Object payload = null) {
+        super(code)
+        this.code = code
+        this.title = title
+        this.detail = detail
+        this.user = user
+        this.payload = payload
+    }
+}


### PR DESCRIPTION
The event logger is in rcm-api : https://github.com/9ci/domain9/pull/2424/commits/0e4ce686e5ab4b546bdbb56eea7bdd7eb6cefca4