### PR TITLE
Add exception handler for throwable

### DIFF
--- a/gorm-rest/src/main/groovy/yakworks/rest/gorm/controller/CrudApiController.groovy
+++ b/gorm-rest/src/main/groovy/yakworks/rest/gorm/controller/CrudApiController.groovy
@@ -288,6 +288,7 @@ trait CrudApiController<D> extends RestApiController {
         }
     }
 
+    @Override
     void handleThrowable(Throwable e) {
         Problem apiError = problemHandler.handleException(e, getEntityClass()?.simpleName)
         respondWith(apiError)

--- a/gorm-rest/src/main/groovy/yakworks/rest/gorm/controller/RestApiController.groovy
+++ b/gorm-rest/src/main/groovy/yakworks/rest/gorm/controller/RestApiController.groovy
@@ -86,9 +86,10 @@ trait RestApiController implements RequestJsonSupport, RestResponder, RestRespon
         }
     }
 
-    // Map getGrailsParams() {
-    //     getParamsMap()
-    // }
+    void handleThrowable(Throwable e) {
+        Problem apiError = problemHandler.handleException(e)
+        respondWith(apiError)
+    }
 
     /**
      * Sometimes the stock getParams will loose the query params that are passed in. Its not clear why.


### PR DESCRIPTION
@basejump Can we merge this, so that exception hadling is consistent between controllers which extend CrudApi and those which directly extend `RestApiController`

I will need this for https://github.com/9ci/domain9/issues/1922