### PR TITLE
Handle query exception

### DIFF
--- a/gorm-tools/src/main/groovy/gorm/tools/mango/MangoDetachedCriteria.groovy
+++ b/gorm-tools/src/main/groovy/gorm/tools/mango/MangoDetachedCriteria.groovy
@@ -264,7 +264,7 @@ class MangoDetachedCriteria<T> extends DetachedCriteria<T> {
                 }
                 return query.list()
             }
-        } catch (IllegalArgumentException | QueryException ex) {
+        } catch (IllegalArgumentException | QueryException | ClassCastException ex) {
             //Hibernate throws IllegalArgumentException when Antlr fails to parse query
             //and throws QueryException when hibernate fails to execute query
             throw toDataProblem(ex)
@@ -319,9 +319,10 @@ class MangoDetachedCriteria<T> extends DetachedCriteria<T> {
         try {
             def list = hq.list(queryInfo.query, queryInfo.paramMap, args)
             return list as List<Map>
-        } catch (IllegalArgumentException | QueryException ex) {
+        } catch (IllegalArgumentException | QueryException | ClassCastException ex) {
             //Hibernate throws IllegalArgumentException when Antlr fails to parse query
             //and throws QueryException when hibernate fails to execute query
+            //of cast exception, if type of value doesnt match field type
             throw toDataProblem(ex)
         }
     }

--- a/gorm-tools/src/test/groovy/gorm/tools/mango/DefaultMangoQuerySpec.groovy
+++ b/gorm-tools/src/test/groovy/gorm/tools/mango/DefaultMangoQuerySpec.groovy
@@ -192,4 +192,14 @@ class DefaultMangoQuerySpec extends Specification implements GormHibernateTest {
         ex.detail.contains("Text 'xxx' could not be parsed")
     }
 
+    void "query fails with class cast exception"() {
+        when:
+        Cust.query("location":[[address:['add 1']]]).list()
+
+        then:
+        DataProblemException ex = thrown()
+        ex.code == 'error.query.invalid'
+        ex.detail.contains "java.util.ArrayList cannot be cast to class java.lang.String"
+    }
+
 }

--- a/gorm-tools/src/test/groovy/gorm/tools/mango/MangoDetachedCriteriaSpec.groovy
+++ b/gorm-tools/src/test/groovy/gorm/tools/mango/MangoDetachedCriteriaSpec.groovy
@@ -1,9 +1,6 @@
 package gorm.tools.mango
 
-
-import gorm.tools.mango.jpql.JpqlQueryBuilder
 import spock.lang.Specification
-import testing.Cust
 import yakworks.testing.gorm.model.KitchenSink
 import yakworks.testing.gorm.unit.GormHibernateTest
 

--- a/gorm-tools/src/test/groovy/gorm/tools/mango/MangoTidyMapSpec.groovy
+++ b/gorm-tools/src/test/groovy/gorm/tools/mango/MangoTidyMapSpec.groovy
@@ -99,6 +99,17 @@ class MangoTidyMapSpec extends Specification {
             ]
         ]
 
+        when:
+        mmap = tidy([
+            "num": ['num1', 'num2']
+        ])
+
+        then:
+        mmap == [
+            num: [
+                    '$in': ['num1', 'num2']
+            ]
+        ]
     }
 
     void "test like"() {


### PR DESCRIPTION
9ci/domain9#3227

@basejump Should we rather have catch all exception, so if any thing fails during hibernate querying, we give back a problem ?